### PR TITLE
feat: enable scss module support

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,7 +30,14 @@ export default [
             resolve(),
             commonjs(),
             typescript({tsconfig: "./tsconfig.json", sourceMap: true, inlineSources: true}),
-            postcss(),
+            postcss({
+                use: ["sass"],
+                autoModules: true,
+                modules: {
+                    generateScopedName: "[name]__[local]___[hash:base64:5]",
+                },
+                sourceMap: true,
+            }),
 
             terser(),
         ],

--- a/src/styles.d.ts
+++ b/src/styles.d.ts
@@ -1,0 +1,4 @@
+declare module "*.module.scss" {
+    const classes: { readonly [key: string]: string };
+    export default classes;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
     "allowSyntheticDefaultImports": true,
     "emitDeclarationOnly": true,
   },
-  "include": ["../jest-setup.ts","src/**/*.ts"],
+  "include": ["../jest-setup.ts","src/**/*"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- configure the Rollup PostCSS pipeline to compile Sass and expose CSS Modules
- add shared TypeScript typings for `*.module.scss` imports
- widen the TypeScript include pattern so the new declarations are picked up

## Testing
- npx jest --runInBand *(fails: 403 Forbidden from npm registry)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914a086fab083299b3ae0c4b2a55d46)